### PR TITLE
Add more robust error handling

### DIFF
--- a/classes/order.py
+++ b/classes/order.py
@@ -638,7 +638,7 @@ class Order(object):
         idx_W, idx_I, idx_O = self.get_optimal_lpf_combination_triple(size_bit_W, access_en_W,
                                                                     size_bit_I, access_en_I,
                                                                     size_bit_O, access_en_O, node_size_bits)
-        
+
         # Update W attributes
         self.allocated_order_W.append(self.remaining_lpf_W[1:idx_W + 1]) # start at 1 to exclude 'None'
         self.remaining_lpf_W = [None] + self.remaining_lpf_W[idx_W + 1:]
@@ -876,6 +876,9 @@ class Order(object):
         i_min = None
         j_min = None
         k_min = None
+
+        if n_1 == 0 or n_2 == 0 or n_3 == 0:
+            raise ValueError("Memory hierarchy is not valid.")
         for i in range(n_1):
             for j in range(n_2):
                 for k in range(n_3):

--- a/classes/order.py
+++ b/classes/order.py
@@ -638,7 +638,6 @@ class Order(object):
         idx_W, idx_I, idx_O = self.get_optimal_lpf_combination_triple(size_bit_W, access_en_W,
                                                                     size_bit_I, access_en_I,
                                                                     size_bit_O, access_en_O, node_size_bits)
-
         # Update W attributes
         self.allocated_order_W.append(self.remaining_lpf_W[1:idx_W + 1]) # start at 1 to exclude 'None'
         self.remaining_lpf_W = [None] + self.remaining_lpf_W[idx_W + 1:]

--- a/evaluate.py
+++ b/evaluate.py
@@ -458,6 +458,8 @@ def mem_scheme_su_evaluate(input_settings, layer_, im2col_layer, layer_index, la
         ################################# CALL PARALLEL PROCESSES ##################################
         pool = Pool(processes=n_processes)
         results = pool.starmap(loma.tl_worker_new, [[tl_chunk] + fixed_args for tl_chunk in tl_list_split])
+        pool.close()
+
 
         #################################     POST PROCESSING     ##################################
         best_output_energy = None
@@ -479,7 +481,10 @@ def mem_scheme_su_evaluate(input_settings, layer_, im2col_layer, layer_index, la
             Path(parent_folder).mkdir(parents=True, exist_ok=True)
 
         # Loop through the best energy/ut found by the parallel processes to find the overall best one
-        for (min_en, min_en_ut, min_en_output, max_ut_en, max_ut, max_ut_output, en_collect, ut_collect, lat_collect) in results:
+        for result in results:
+            if isinstance(result, Exception):
+                continue
+            min_en, min_en_ut, min_en_output, max_ut_en, max_ut, max_ut_output, en_collect, ut_collect, lat_collect = result
             if (min_en < best_energy or (min_en == best_energy and min_en_ut > best_energy_utilization)):
                 best_energy = min_en
                 best_energy_utilization = min_en_ut
@@ -511,6 +516,8 @@ def mem_scheme_su_evaluate(input_settings, layer_, im2col_layer, layer_index, la
                 #     f.close()
 
         # Convert output, which is just best allocated order at this point, to a CostModelOutput object
+        if best_output_utilization is None or best_output_energy is None:
+            return
         best_output_energy = loma.get_cost_model_output(best_output_energy, input_settings, mem_scheme, layer_comb, spatial_loop_comb, ii_su)
         best_output_utilization = loma.get_cost_model_output(best_output_utilization, input_settings, mem_scheme, layer_comb, spatial_loop_comb, ii_su)
 
@@ -941,7 +948,6 @@ def mem_scheme_list_evaluate(input_settings, mem_scheme, mem_scheme_index, layer
             procs.append(Process(target=mem_scheme_evaluate,
                                  args=(input_settings, layer_number, layer, im2col_layer,
                                        mem_scheme, mem_scheme_index, multi_manager)))
-
         for p in procs: p.start()
         for p in procs: p.join()
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -460,7 +460,6 @@ def mem_scheme_su_evaluate(input_settings, layer_, im2col_layer, layer_index, la
         results = pool.starmap(loma.tl_worker_new, [[tl_chunk] + fixed_args for tl_chunk in tl_list_split])
         pool.close()
 
-
         #################################     POST PROCESSING     ##################################
         best_output_energy = None
         best_output_utilization = None
@@ -948,6 +947,7 @@ def mem_scheme_list_evaluate(input_settings, mem_scheme, mem_scheme_index, layer
             procs.append(Process(target=mem_scheme_evaluate,
                                  args=(input_settings, layer_number, layer, im2col_layer,
                                        mem_scheme, mem_scheme_index, multi_manager)))
+
         for p in procs: p.start()
         for p in procs: p.join()
 

--- a/loma.py
+++ b/loma.py
@@ -649,7 +649,11 @@ def tl_worker_new(tl_list, merged_count_dict, loop_type_order, total_merged_coun
                                         allocated_order = order.allocate_remaining()
                                         break
                                     for node in nodes[level]:
-                                        order.allocate_memory(node, level)
+                                        try:
+                                            order.allocate_memory(node, level)
+                                        except Exception as e:
+                                            print(f'{type(e).__name__}: {e}')
+                                            return e
                                 
                                 # print(merged_order)
                                 # print('W\t', allocated_order['W'])
@@ -682,13 +686,17 @@ def tl_worker_new(tl_list, merged_count_dict, loop_type_order, total_merged_coun
                                 else:
                                     loop_fractional = loop
 
-                                utilization = cls.Utilization.get_utilization(layer_rounded, temporal_loop,
-                                                                              spatial_loop_comb, loop,
-                                                                              input_settings.mac_array_info,
-                                                                              mem_scheme.mem_size,
-                                                                              mem_scheme.mem_share, mem_scheme.mem_type,
-                                                                              input_settings.mac_array_stall,
-                                                                              input_settings.precision, mem_scheme.mem_bw)
+                                try:
+                                    utilization = cls.Utilization.get_utilization(layer_rounded, temporal_loop,
+                                                                                  spatial_loop_comb, loop,
+                                                                                  input_settings.mac_array_info,
+                                                                                  mem_scheme.mem_size,
+                                                                                  mem_scheme.mem_share, mem_scheme.mem_type,
+                                                                                  input_settings.mac_array_stall,
+                                                                                  input_settings.precision, mem_scheme.mem_bw)
+                                except Exception as e:
+                                    print(f'{type(e).__name__}: {e}')
+                                    return e
                                 operand_cost = {'W':[], 'I':[], 'O':[]}
                                 total_cost_layer = 0
                                 for operand in ['W', 'I', 'O']:


### PR DESCRIPTION
When executing ZigZag over a pool of hardware configurations, it can happen that certain NN layer and HW settings result in invalid combinations. This can result into errors in zigzag that are not always handled in a clean manner. (e.g. it can happen that certain threads in the multiprocessing are not cleaned up)

This PR adds support for errors in certain parts of the code base.